### PR TITLE
Use custom Users instance in TransactionsViewSet

### DIFF
--- a/drf_test/transactions/views.py
+++ b/drf_test/transactions/views.py
@@ -8,7 +8,13 @@ class TransactionsViewSet(viewsets.ModelViewSet):
     serializer_class = TransactionsSerializers
     permission_classes = [permissions.IsAuthenticated, TokenHasReadWriteScope]
     def get_queryset(self):
-        user = self.request.user
+        user_email = getattr(self.request.user, "email", None)
+        if not user_email:
+            return Transactions.objects.none()
+        try:
+            user = Users.objects.get(email=user_email)
+        except Users.DoesNotExist:
+            return Transactions.objects.none()
         return Transactions.objects.filter(user_id=user)
 
 


### PR DESCRIPTION
## Summary
- Retrieve custom Users record matching the authenticated user's email
- Filter transactions by the custom Users instance

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68967a486cd08328882d3a7fefc76df7