### PR TITLE
Fix user filter in transaction viewset

### DIFF
--- a/drf_test/transactions/views.py
+++ b/drf_test/transactions/views.py
@@ -9,7 +9,7 @@ class TransactionsViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated, TokenHasReadWriteScope]
     def get_queryset(self):
         user = self.request.user
-        return Transactions.objects.filter(user_id=user)
+        return Transactions.objects.filter(user_id_id=user.id)
 
 
 class UsersViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- ensure TransactionsViewSet filters transactions by the authenticated user's ID

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_689676d5b3b48328a761bcaf73db96c9