### PR TITLE
Add docstrings for user and bank account serializers

### DIFF
--- a/drf_test/transactions/serializers.py
+++ b/drf_test/transactions/serializers.py
@@ -19,13 +19,13 @@ class TransactionsSerializers(serializers.ModelSerializer):
 
 
 class UsersSerializers(serializers.ModelSerializer):
-    """"""
+    """Serializer for the Users model."""
     class Meta:
         model = Users
         fields = '__all__'
 
 class BankAccountSerializers(serializers.ModelSerializer):
-    """"""
+    """Serializer for the BankAccount model."""
     class Meta:
         model = BankAccount
         fields = '__all__'


### PR DESCRIPTION
## Summary
- add docstring for user serializer
- add docstring for bank account serializer

## Testing
- `python drf_test/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68967a53be4c832883b4539572fab313