### PR TITLE
Add CreditCard encryption test

### DIFF
--- a/drf_test/transactions/tests.py
+++ b/drf_test/transactions/tests.py
@@ -1,3 +1,22 @@
+from datetime import date
+
 from django.test import TestCase
 
-# Create your tests here.
+from .models import CreditCard
+
+
+class CreditCardModelTest(TestCase):
+    def test_credit_card_number_encrypted_and_decrypted(self):
+        original_number = "4111111111111111"
+
+        card = CreditCard.objects.create(
+            number=original_number,
+            brand="visa",
+            end_date=date(2030, 1, 1),
+        )
+
+        # The stored number should be encrypted and differ from the original
+        self.assertNotEqual(card.number, original_number)
+
+        # decrypted_number should return the original number
+        self.assertEqual(card.decrypted_number, original_number)


### PR DESCRIPTION
## Summary
- add test verifying CreditCard numbers are stored encrypted and decrypted correctly

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install django` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68967a527c34832892da53cf8b5c6e2b